### PR TITLE
Fix connector to use proper gateway url

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,8 +58,13 @@ func main() {
 		}
 	}
 
+	gatewayURL := os.Getenv("OPENFAAS_URL")
+	if val, exists := os.LookupEnv("gateway_url"); exists {
+		gatewayURL = val
+	}
+
 	config := types.ControllerConfig{
-		GatewayURL:      os.Getenv("OPENFAAS_URL"),
+		GatewayURL:      gatewayURL,
 		PrintResponse:   false,
 		RebuildInterval: time.Second * 10,
 		UpstreamTimeout: time.Second * 15,

--- a/yaml/connector-dep.yml
+++ b/yaml/connector-dep.yml
@@ -16,10 +16,12 @@ spec:
     spec:
       containers:
       - name: vcenter
-        image: functions/vcenter-connector:0.1.0
+        image: docwareiy/vcenter-connector:0.2.0
         command: ["./connector"]
         args: ["--vcenter-url", "http://user:pass@vcsim.openfaas:8989/sdk", "--insecure"]
         env:
+          - name: gateway_url
+            value: "http://gateway.openfaas:8080"
           - name: topics
             value: "vm.powered.on,"
           - name: basic_auth

--- a/yaml/vcsim-server-dep.yml
+++ b/yaml/vcsim-server-dep.yml
@@ -16,8 +16,8 @@ spec:
     spec:
       containers:
       - name: vcsim
-        image: docwareiy/vcsim:0.2.0
+        image: docwareiy/vcsim:0.1.0-r
         command: ["./vcsim"]
-        args: ["-tls", "false"]
+        args: ["-tls=false", "-httptest.serve", ":8989"]
         ports:
         - containerPort: 8989


### PR DESCRIPTION
This fixes connector code to to properly set gateway url to `container.namespace` when deployed in a cluster. Changes to use latest stable images for both `vcenter-connector` and `vcsim`

Once images are tagged and pushed to `functions/` this needs an update.

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>