### PR TITLE
Add Dockerfile for govc

### DIFF
--- a/govc/Dockerfile
+++ b/govc/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.11.4-alpine as builder
+
+RUN apk add git --no-cache
+
+WORKDIR /root/go/src/github.com/vmware/
+RUN git clone https://github.com/vmware/govmomi
+
+WORKDIR /root/go/src/github.com/vmware/govmomi
+ENV GOPATH=/root/go/
+RUN CGO_ENABLED=0 GOOS=linux go build -o govc/govc govc/main.go
+
+FROM alpine:3.8
+
+WORKDIR /root/
+
+EXPOSE 8989
+COPY --from=builder //root/go/src/github.com/vmware/govmomi/govc/govc .
+
+CMD ["./govc"]


### PR DESCRIPTION
- Follows the syntax from #1 (even though `apk add git` seems redundant
in a golang image (suggest making use of `go get`)
- Default behaviour when the image is executed runs `govc` which
outputs supported commands (can be overwritten)
- In the README instructions for the connector we should mention how to
correctly invoke `govc`, incl. commonly used environment variables
(https://github.com/vmware/govmomi/tree/master/govc#usage).

Signed-off-by: Michael Gasch <embano1@live.com>