### PR TITLE
Update Connector Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /home/app
 
 EXPOSE 8989
 
-COPY --from=builder /go/src/github.com/openfaas-incubator/vcenter-connector/    .
+COPY --from=builder /go/src/github.com/openfaas-incubator/vcenter-connector/connector    .
 
 RUN chown -R app:app ./
 


### PR DESCRIPTION
- There is no need to copy the full build context into the final stage image
- Changed to only copy the connector binary to the final image

Signed-off-by: Michael Gasch <embano1@live.com>