### PR TITLE
Updates to README and connector deployment

### DIFF
--- a/yaml/kubernetes/connector-dep.yml
+++ b/yaml/kubernetes/connector-dep.yml
@@ -18,6 +18,7 @@ spec:
         image: embano1/faas-vcconnector:0.2
         command: ["./connector"]
         args: ["-vcenter", "https://vcenter.ip", "-vc-user", "vcuser", "-vc-pass", "vcpass", "-insecure", "-gateway", "http://gateway.openfaas:8080"]
+      # if you do not have authentication enabled for OpenFaaS comment everything below out (incl. volumes)
         env:
           - name: basic_auth
             value: "true"
@@ -27,7 +28,6 @@ spec:
             - name: gateway-basic-auth
               readOnly: true
               mountPath: "/var/secrets/"
-      # if you do not have authentication enabled for OpenFaaS comment this out 
       volumes:
       - name: gateway-basic-auth
         secret:


### PR DESCRIPTION
This commit improves the documentation and fixes authentication issues
with the deployment file:

- Add possibility to use `vcsim` as vCenter backend
- Fixed an issue with the connector deployment manifest when OpenFaaS auth is not used
- Fixed an issue when the OpenFaaS template for the example function is
not pulled
- Improved documentation for IP/PORT/URL schemes used throughout the
example

Signed-off-by: Michael Gasch <embano1@live.com>