### PR TITLE
Added ObjectName to OutboundEvent

### DIFF
--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,12 +1,19 @@
 package events
 
-import "testing"
-import vtypes "github.com/vmware/govmomi/vim25/types"
+import (
+	"reflect"
+	"testing"
+
+	vtypes "github.com/vmware/govmomi/vim25/types"
+)
 
 var (
 	vmEvent = &vtypes.VmEvent{
 		Event: vtypes.Event{
 			Vm: &vtypes.VmEventArgument{
+				EntityEventArgument: vtypes.EntityEventArgument{
+					Name: "Windows10-1234",
+				},
 				Vm: vtypes.ManagedObjectReference{
 					Type:  "VirtualMachine",
 					Value: "vm-1234",
@@ -17,6 +24,9 @@ var (
 
 	resourcePoolEvent = &vtypes.ResourcePoolEvent{
 		ResourcePool: vtypes.ResourcePoolEventArgument{
+			EntityEventArgument: vtypes.EntityEventArgument{
+				Name: "Management-RP-1234",
+			},
 			ResourcePool: vtypes.ManagedObjectReference{
 				Type:  "ResourcePool",
 				Value: "resgroup-1234",
@@ -29,32 +39,31 @@ var (
 	}
 )
 
-var tests = []struct {
-	name    string
-	event   vtypes.BaseEvent
-	moref   *vtypes.ManagedObjectReference
-	motype  string
-	movalue string
-}{
-	{"valid VM Event", vmEvent, &vmEvent.Vm.Vm, "VirtualMachine", "vm-1234"},
-	{"valid ResourcePool Event", resourcePoolEvent, &resourcePoolEvent.ResourcePool.ResourcePool, "ResourcePool", "resgroup-1234"},
-	// assert that ManagedObjectReference will be nil for events we don't support (yet), so it won't be marshaled in the outbound JSON
-	{"unsupported Event", unsupportedEvent, nil, "", ""},
-}
+func TestGetObjectNameAndMoRef(t *testing.T) {
 
-func TestGetMoref(t *testing.T) {
-	for _, test := range tests {
-		t.Logf("running test: %q", test.name)
-		ref := getMoref(test.event)
-		if ref != test.moref {
-			t.Errorf("Received incorrect MoRef, got: %v, want: %v", ref, test.moref)
+	var testCases = []struct {
+		name        string
+		event       vtypes.BaseEvent
+		wantMoref   *vtypes.ManagedObjectReference
+		wantObjName string
+	}{
+		{"valid VM Event", vmEvent, &vmEvent.Vm.Vm, "Windows10-1234"},
+		{"valid ResourcePool Event", resourcePoolEvent, &resourcePoolEvent.ResourcePool.ResourcePool, "Management-RP-1234"},
+		// assert that ManagedObjectReference and ObjectName will be nil for events we don't support (yet), so it won't be marshaled in the outbound JSON
+		{"unsupported Event", unsupportedEvent, nil, ""},
+	}
+
+	for _, test := range testCases {
+		name, ref := getObjectNameAndMoref(test.event)
+
+		// test MoRef
+		if eq := reflect.DeepEqual(test.wantMoref, ref); !eq {
+			t.Errorf("%s: wanted: %v, got: %v", test.name, test.wantMoref, ref)
 		}
 
-		if ref != nil {
-			if ref.Value != test.movalue {
-				t.Errorf("Received incorrect MoRef value, got: %v, want: %v", ref.Value, test.movalue)
-			}
+		// test ObjectName
+		if eq := reflect.DeepEqual(test.wantObjName, name); !eq {
+			t.Errorf("%s: wanted: %v, got: %v", test.name, test.wantObjName, name)
 		}
-
 	}
 }


### PR DESCRIPTION
In certain cases the ManagedObjectReference alone might not be useful, e.g. when an object is deleted.

This commit adds a new field `objectName` to the outbound JSON data which serves as additional metadata for the receiver.

Note: ObjectName for certain vSphere objects, e.g. virtual machines, is only unique within a folder (if applicable) as per the description [here](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-76E73C62-A973-4839-BB67-AC1817908E6D.html).

This added field should be treated as metadata and not for requests against vCenter (use `ManagedObjectReference` instead).

Signed-off-by: Michael Gasch <embano1@live.com>