### PR TITLE
Add vCenter Source to Event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vcenter-connector
+yaml/kubernetes/connector-dep-prod.yml


### PR DESCRIPTION
resolves #22 

This PR adds the vcenter source to the OutboundEvent, allowing the subscribed function(s) to handle events across multiple vcenters.